### PR TITLE
Log query in the exception

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/query/SqlQuery.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/SqlQuery.java
@@ -392,8 +392,8 @@ public class SqlQuery extends Query {
     // just bad SQL
     if (!macro.find() && !param.find())
       throw new WdkModelException(String.format("Database error while "
-          + "attempting to parse sqlQuery %s",
-        getFullName()), ex);
+          + "attempting to parse sqlQuery %s: %s",
+        getFullName(), sql), ex);
 
     var invalid = _columnMap.values().stream()
       .anyMatch(not(Column::wasTypeSet));


### PR DESCRIPTION
As a user of this code, I was very unsatisfied with the following exception:
```
Caused by: org.gusdb.wdk.model.WdkModelException: Database error while attempting to parse sqlQuery DatasetAttributes.All
        at org.gusdb.wdk.model.query.SqlQuery.handleColumnTypeException(SqlQuery.java:394)
        at org.gusdb.wdk.model.query.SqlQuery.resolveColumnTypes(SqlQuery.java:356)
        at org.gusdb.wdk.model.record.RecordClass.assignAttributeFieldDataTypes(RecordClass.java:958)
        at org.gusdb.wdk.model.record.RecordClass.resolveAttributeQueryReferences(RecordClass.java:948)
        ... 12 more
Caused by: java.sql.SQLSyntaxErrorException: ORA-00942: table or view does not exist
```

because I didn't know where to look for it. After making this change I got the sql, and I was able to see that DatasetAttributes.All is something in
`$PROJECT_HOME/EbrcModelCommon/Model/lib/wdk/model/records/datasetRecords.xml`

but this wasn't logged anywhere earlier.

I think everyone else will like this change too. Who doesn't like to be confronted with their bad sql?