### PR TITLE
Make a common log message into a debug not info

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/query/param/FilterParamNew.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/param/FilterParamNew.java
@@ -611,7 +611,7 @@ public class FilterParamNew extends AbstractDependentParam {
 
     try {
       long start = System.currentTimeMillis();
-      LOG.info(filteredDistinctFilterItemsSql);
+      LOG.debug(filteredDistinctFilterItemsSql);
       ps = SqlUtils.getPreparedStatement(dataSource, filteredDistinctFilterItemsSql);
       ps.setString(1, ontologyId);
       resultSet = ps.executeQuery();


### PR DESCRIPTION
This is a bit too common in the logs:

```
[18/May/2020|12:56:36] sid:69EE2 rid:  355    9982ms    68.82.218.57 - INFO  - org.gusdb.wdk.model.query.param.FilterParamNew:614 - SELECT count (distinct internal) as cnt FROM (select internal from (SELECT o.*  FROM (select aa.sample_id as internal,
                   aa.taxon_level_name || ':' || aa.taxon_name as ontology_term_name,
                   cast(aa.relative_abundance as number) as number_value,
                   cast(null as date) as date_value,
                   cast(null as varchar2(1)) as string_value
            from 
                 apidbUserDatasets.UD_AggregatedAbundance aa
            where 
              aa.user_dataset_id in (17320)
) o) bq WHERE bq.ontology_term_name = ? INTERSECT select internal from ( /* START filteredIdsSql */ /* START filterSelectSql */ SELECT distinct md.internal FROM ( /* START metadataSql */ SELECT o.*  FROM (select aa.sample_id as internal,
                   aa.taxon_level_name || ':' || aa.taxon_name as ontology_term_name,
                   cast(aa.relative_abundance as number) as number_value,
                   cast(null as date) as date_value,
                   cast(null as varchar2(1)) as string_value
            from 
                 apidbUserDatasets.UD_AggregatedAbundance aa
            where 
              aa.user_dataset_id in (17320)
) o /* END metadataSql */ )md /* END filterSelectSql */ where ontology_term_name = 'kingdom:Bacteria' /* END filteredIdsSql */ ) fi) fs
```