### PR TITLE
Add "isExample" field to strategy response JSON

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/core/api/JsonKeys.java
+++ b/Model/src/main/java/org/gusdb/wdk/core/api/JsonKeys.java
@@ -258,6 +258,7 @@ public class JsonKeys {
   public static final String LAST_MODIFIED = "lastModified";
   public static final String IS_SAVED = "isSaved";
   public static final String IS_DELETED = "isDeleted";
+  public static final String IS_EXAMPLE = "isExample";
   public static final String STEP_TREE = "stepTree";
   public static final String STEP_ID = "stepId";
   public static final String STEPS = "steps";

--- a/Model/src/main/java/org/gusdb/wdk/model/user/Strategy.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/Strategy.java
@@ -415,6 +415,13 @@ public class Strategy implements StepContainer, Validateable<Strategy> {
     return _isPublic;
   }
 
+  public boolean isExample() {
+    String userDisplayName = _user.getDisplayName();
+    String exampleStratsAuthorName = _wdkModel.getExampleStratsAuthor().getName();
+
+    return userDisplayName.equals(exampleStratsAuthorName);
+  }
+
   public String getProjectId() {
     return _projectId;
   }

--- a/Service/doc/schema/wdk/includes/strategy-no-step-tree.json
+++ b/Service/doc/schema/wdk/includes/strategy-no-step-tree.json
@@ -48,6 +48,9 @@
     "isDeleted": {
       "type": "boolean"
     },
+    "isExample": {
+      "type": "boolean"
+    },
     "organization": {
       "type": "string"
     },
@@ -66,7 +69,8 @@
     "isDeleted",
     "isSaved",
     "isValid",
-    "isPublic"
+    "isPublic",
+    "isExample"
   ]
 }
 

--- a/Service/src/main/java/org/gusdb/wdk/service/formatter/StrategyFormatter.java
+++ b/Service/src/main/java/org/gusdb/wdk/service/formatter/StrategyFormatter.java
@@ -44,6 +44,7 @@ public class StrategyFormatter {
         .put(JsonKeys.IS_SAVED, strategy.isSaved())
         .put(JsonKeys.IS_VALID, strategy.isValid())
         .put(JsonKeys.IS_DELETED, strategy.isDeleted())
+        .put(JsonKeys.IS_EXAMPLE, strategy.isExample())
         .put(JsonKeys.ORGANIZATION, strategy.getUser().getProfileProperties().get("organization"))
         .put(JsonKeys.ESTIMATED_SIZE, StepFormatter.translateEstimatedSize(strategy.getEstimatedSize()))
         .put(JsonKeys.NAME_OF_FIRST_STEP, strategy.getMostPrimaryLeafStep().getDisplayName())


### PR DESCRIPTION
This PR adds an `isExample` field to the strategy response JSON. The need for this field arises from a recent bug with the "Sort VEuPathDB Example Strategies To Top" checkbox on the client's "Public Strategies" listing. This bug is occurring because the client is hardcoding the name of the example strategies author instead of using the existing `exampleStratsAuthor` model property.

Note: in this implementation, the `isExample` field is derived based on whether the strategy owner's display name matches the `exampleStratsAuthor` model property. During a recent FUT, we realized that in the longer term, it might make sense to have the `exampleStratsAuthor` be the *id* of the example strategy user. That way, we would not have to update `exampleStratsAuthor` whenever the underlying user is renamed.