### PR TITLE
Corrected issue causing all iRODS events to be processed each time.

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/UserDatasetEventDBActions.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/UserDatasetEventDBActions.java
@@ -147,7 +147,14 @@ public class UserDatasetEventDBActions
       + " WHERE status = '" + UserDatasetEventStatus.CLEANUP_COMPLETE + "'";
 
     return new SQLRunner(ds, sql)
-      .executeQuery(rs -> rs.next() ? Optional.of(rs.getLong(1)) : Optional.empty());
+      .executeQuery(rs -> {
+        if (!rs.next())
+          return Optional.empty();
+
+        final var id = rs.getLong(1);
+
+        return rs.wasNull() ? Optional.empty() : Optional.of(id);
+      });
   }
 
   /**


### PR DESCRIPTION
Fixed cleanup_ready event lookup to returning 0 instead of null when no such event was found.