### PR TITLE
Map Delayed Result Exception

### DIFF
--- a/Service/src/main/java/org/gusdb/wdk/service/provider/ExceptionMapper.java
+++ b/Service/src/main/java/org/gusdb/wdk/service/provider/ExceptionMapper.java
@@ -96,8 +96,14 @@ public class ExceptionMapper implements javax.ws.rs.ext.ExceptionMapper<Exceptio
     }
 
     catch (WdkDelayedResultException ex) {
-      return logResponse(e, Response.status(Status.CONFLICT)
-          .type(MediaType.TEXT_PLAIN).entity(DELAYED_RESULT_MESSAGE).build());
+      return logResponse(e, Response.status(Status.ACCEPTED)
+          .type(MediaType.TEXT_PLAIN)
+          .entity(
+            new JSONObject()
+              .put("status", "accepted")
+              .put("message", DELAYED_RESULT_MESSAGE)
+              .toString()
+          ).build());
     }
 
     // Some other exception that must be handled by the application; send error event


### PR DESCRIPTION
This PR maps `WdkDelayedResultException`s to a 202 - ACCEPTED response.

**Notes:**
1. The first paragraph [here](https://restfulapi.net/http-status-202-accepted) does a nice, succinct job explaining why I opted for the status code 202.
2. In the future, we might consider enriching the response with instructions on how to check on the delayed result, an estimated time to completion, etc.