### PR TITLE
attach user to temporary result

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/cache/CacheMgr.java
+++ b/Model/src/main/java/org/gusdb/wdk/cache/CacheMgr.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.gusdb.fgputil.MapBuilder;
+import org.gusdb.fgputil.Tuples.TwoTuple;
 import org.gusdb.fgputil.cache.InMemoryCache;
 import org.gusdb.fgputil.cache.ManagedMap;
 import org.gusdb.fgputil.db.cache.SqlCountCache;
@@ -35,7 +36,7 @@ public class CacheMgr {
   private final InMemoryCache<String, List<Map<String,Object>>> _attributeMetaQueryCache = new InMemoryCache<>();
   private final MetadataNewCache _metadataNewCache = new MetadataNewCache();
   private final OntologyCache _ontologyCache = new OntologyCache();
-  private final ManagedMap<String, AnswerRequest> _answerRequestCache = new ManagedMap<>();
+  private final ManagedMap<String, TwoTuple<Long,AnswerRequest>> _answerRequestCache = new ManagedMap<>();
 
   private final Map<String,InMemoryCache<?,?>> _cacheRepo =
       new MapBuilder<String,InMemoryCache<?,?>>(new LinkedHashMap<String,InMemoryCache<?,?>>())
@@ -54,7 +55,7 @@ public class CacheMgr {
   public InMemoryCache<String, List<Map<String,Object>>> getAttributeMetaQueryCache() { return _attributeMetaQueryCache; }
   public MetadataNewCache getMetadataNewCache() { return _metadataNewCache; }
   public OntologyCache getOntologyNewCache() { return _ontologyCache; }
-  public ManagedMap<String, AnswerRequest> getAnswerRequestCache() { return _answerRequestCache; }
+  public ManagedMap<String, TwoTuple<Long,AnswerRequest>> getAnswerRequestCache() { return _answerRequestCache; }
 
   // special getter lazily populates the repo with db-specific count caches
   public synchronized SqlCountCache getSqlCountCache(DatabaseInstance db) {

--- a/Service/src/main/java/org/gusdb/wdk/service/service/TemporaryResultService.java
+++ b/Service/src/main/java/org/gusdb/wdk/service/service/TemporaryResultService.java
@@ -77,8 +77,7 @@ public class TemporaryResultService extends AbstractWdkService {
       throws RequestMisformatException, DataValidationException, WdkModelException, ValidationException {
     AnswerRequest request = parseRequest(requestJson);
     String id = UUID.randomUUID().toString();
-    User user = getSessionUser();
-    CacheMgr.get().getAnswerRequestCache().put(id, new TwoTuple<>(user.getUserId(), request));
+    CacheMgr.get().getAnswerRequestCache().put(id, new TwoTuple<>(getSessionUser().getUserId(), request));
     return Response.ok(new JSONObject().put(ID, id).toString())
         .location(getUriInfo().getAbsolutePathBuilder().build(id)).build();
   }
@@ -108,6 +107,8 @@ public class TemporaryResultService extends AbstractWdkService {
       }
       throw new NotFoundException(formatNotFound("temporary result with ID '" + id + "'"));
     }
+
+    // request is valid; produce result as originally requested
     return AnswerService.getAnswerResponse(user, savedRequest.getValue()).getSecond();
   }
 

--- a/Service/src/main/java/org/gusdb/wdk/service/service/TemporaryResultService.java
+++ b/Service/src/main/java/org/gusdb/wdk/service/service/TemporaryResultService.java
@@ -97,7 +97,7 @@ public class TemporaryResultService extends AbstractWdkService {
         // 1. ID invalid or no longer in cache
         savedRequest == null ||
         // 2. Request creation date is too long in the past
-        savedRequest.getValue().getCreationDate().getTime() < new Date().getTime() - EXPIRATION_MILLIS ||
+        savedRequest.getSecond().getCreationDate().getTime() < new Date().getTime() - EXPIRATION_MILLIS ||
         // 3. User who created the request is no longer valid
         (user = getWdkModel().getUserFactory().getUserById(savedRequest.getFirst()).orElse(null)) == null
     ) {
@@ -109,7 +109,7 @@ public class TemporaryResultService extends AbstractWdkService {
     }
 
     // request is valid; produce result as originally requested
-    return AnswerService.getAnswerResponse(user, savedRequest.getValue()).getSecond();
+    return AnswerService.getAnswerResponse(user, savedRequest.getSecond()).getSecond();
   }
 
   private AnswerRequest parseRequest(JSONObject requestJson)


### PR DESCRIPTION
It occurred to me that we were creating the temporary result with the current session user but then accessing it with some (potentially new) session user, esp if we are passing the URL around to another service that doesn't have the original cookie.  This change will ensure that the result will run as the user who created the temporary result; output should be predictably be as expected.