### PR TITLE
Fixes WDK #30: Improved request completion logging

### DIFF
--- a/Service/src/main/java/org/gusdb/wdk/service/filter/RequestLoggingFilter.java
+++ b/Service/src/main/java/org/gusdb/wdk/service/filter/RequestLoggingFilter.java
@@ -182,6 +182,7 @@ public class RequestLoggingFilter implements ContainerRequestFilter, ContainerRe
       // exception while writing response body; log error, then status
       LOG.error("Failure to write response body", e);
       logRequestCompletion(httpStatus, "write failed", context::getProperty, context::removeProperty);
+      throw e;
     }
   }
 


### PR DESCRIPTION
At scrum I did not remember why we used a WriterInterceptor to record the end of the request vs a ResponseFilter.  The reason is: a response filter executes at the beginning of the delivery of the response payload, so can be useful in e.g. changing the HTTP response code.  A WriterInterceptor executes only when there is a response body BUT can perform logic at the beginning and/or end of the body-writing process.  Thus, if we want a log line at the VERY end of the request (i.e. after the response has completely been written), we need a WriterInterceptor.  If we want a log line for every request (i.e. those with and without bodies) we need a ResponseFilter.  So, the code here uses both!  I tried to make the verbiage clear about when and what the individual log lines mean.