### PR TITLE
Add hard pagination to the dataset sync script.

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/UserDatasetEventListHandler.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/UserDatasetEventListHandler.java
@@ -17,6 +17,7 @@ public class UserDatasetEventListHandler extends BaseCLI {
   protected static final String ARG_PROJECT = "project";
   protected static final String ARG_EVENTS_FILE = "eventsFile";
   protected static final String ARG_RUN_MODE = "mode";
+  protected static final String ARG_MAX_EVENTS = "maxEvents";
 
   private static final Logger logger = Logger.getLogger(UserDatasetEventListHandler.class);
 
@@ -48,9 +49,12 @@ public class UserDatasetEventListHandler extends BaseCLI {
         break;
       case "sync":
         new UserDatasetEventSync(projectId)
-          .handleEventList(UserDatasetEventSync.parseEventsArray(EventParser.parseList(
-            new File((String) getOptionValue(ARG_EVENTS_FILE))
-          )));
+          .handleEventList(
+            UserDatasetEventSync.parseEventsArray(
+              EventParser.parseList(new File((String) getOptionValue(ARG_EVENTS_FILE)))
+            ),
+            Integer.parseInt((String) getOptionValue(ARG_MAX_EVENTS))
+          );
         break;
       default:
         throw new Exception("Unknown run mode, must be one of \"sync\" or \"cleanup\"");
@@ -62,5 +66,6 @@ public class UserDatasetEventListHandler extends BaseCLI {
     addSingleValueOption(ARG_PROJECT, true, null, "The project of the app db");
     addSingleValueOption(ARG_EVENTS_FILE, true, null, "File containing an ordered JSON Array of user dataset events");
     addSingleValueOption(ARG_RUN_MODE, true, null, "One of 'sync' or 'cleanup'.");
+    addSingleValueOption(ARG_MAX_EVENTS, false, "150", "Maximum number of events to process.");
   }
 }

--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/UserDatasetEventSync.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/UserDatasetEventSync.java
@@ -28,6 +28,20 @@ public class UserDatasetEventSync extends UserDatasetEventProcessor
   private static final String LogStrSkipEvent = "%s event %d refers to typeHandler %s which is not"
     + " present in the wdk configuration. Skipping the install but declaring the event as handled.";
 
+  /**
+   * Maximum number of user datasets that will be handled per execution of this
+   * script.
+   *
+   * This is done due to connection leaks in the iRODS job handling on
+   * long-running sessions.
+   *
+   * As this job is called every 5 minutes by Jenkins, this limit will not
+   * prevent all jobs from being processed.  Subsequent Jenkins runs will pick
+   * up where the previous installer execution left off and will install the
+   * next batch of the configured number of datasets.
+   */
+  private static final int MaxDatasetsPerExecution = 150;
+
   public UserDatasetEventSync(String projectId) throws WdkModelException {
     super(projectId);
   }
@@ -57,6 +71,11 @@ public class UserDatasetEventSync extends UserDatasetEventProcessor
       // be installed on the system as type handlers should only be added and
       // removed at release time when the UD database is emptied.
       for (final var event : eventList) {
+        if (count >= MaxDatasetsPerExecution) {
+          LOG.debug("Processed {} datasets, ending execution.", count);
+          break;
+        }
+
         LOG.info("Processing event {}", event.getEventId());
 
         final var eventRow = new EventRow(


### PR DESCRIPTION
Dataset sync script will now run the configured number of events at most per execution.

Subsequent executions of the script will pick up where the previous execution left off and continue processing events.