### PR TITLE
populate sharedWith for my datasets

### DIFF
--- a/Service/src/main/java/org/gusdb/wdk/service/formatter/UserDatasetFormatter.java
+++ b/Service/src/main/java/org/gusdb/wdk/service/formatter/UserDatasetFormatter.java
@@ -31,7 +31,7 @@ public class UserDatasetFormatter implements UserDatasetsFormatter {
   public void addUserDatasetInfoToJsonArray(UserDatasetInfo dataset,
       JSONArray datasetsJson, UserDatasetSession dsSession) throws WdkModelException {
     datasetsJson.put(_expandDatasets
-        ? getUserDatasetJson(dataset, false, false)
+        ? getUserDatasetJson(dataset, true, false)
         : dataset.getDataset().getUserDatasetId());
   }
 
@@ -39,7 +39,7 @@ public class UserDatasetFormatter implements UserDatasetsFormatter {
   public void addSharedDatasetInfoToJsonArray(UserDatasetInfo dataset,
       JSONArray datasetsJson, UserDatasetSession dsSession) throws WdkModelException {
     datasetsJson.put(_expandDatasets
-        ? getUserDatasetJson(dataset, true, false)
+        ? getUserDatasetJson(dataset, false, false)
         : dataset.getDataset().getUserDatasetId());
   }
 


### PR DESCRIPTION
Addresses #43 

Updates to `getAllUserDatasets` so we populate "sharedWith" when listing datasets that the user owns and do not populate the field when listing datasets owned by others.

Possible enhancement would be to avoid use enums instead of booleans to avoid this type of potential mixup.

![Screen Shot 2022-07-28 at 1 30 33 PM](https://user-images.githubusercontent.com/3497580/181600958-8adea4ff-e52a-45a2-9db5-8e593198969a.png)

