### PR TITLE
Added validation to ListDatasetParser

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/dataset/ListDatasetParser.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/dataset/ListDatasetParser.java
@@ -2,7 +2,14 @@ package org.gusdb.wdk.model.dataset;
 
 import org.gusdb.wdk.model.WdkUserException;
 
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+/**
+ * Parser expecting a list of identifiers. The parser was originally intended to support multiple 
+ */
 public class ListDatasetParser extends AbstractDatasetParser {
+  private static Pattern VALID_ID_PATTERN = Pattern.compile("[a-zA-Z0-9\\(\\)\\.\\:_-]+");
 
   // scrum Feb 2 2016: we allow all these characters as row dividers, do not expect columns
   private static final String ROW_DIVIDER = "[\\s,;]+";
@@ -68,6 +75,10 @@ public class ListDatasetParser extends AbstractDatasetParser {
           "The input data for datasetParam has various columns at row #" + parsedRowNum
             + ". The number of columns must be the same for all the rows."
         );
+      if (!Arrays.stream(columns).allMatch(col -> VALID_ID_PATTERN.matcher(col).matches())) {
+        throw new WdkUserException("The input data for datasetParam contains invalid IDs that do not conform to "
+            + VALID_ID_PATTERN.pattern() + " at row # " + parsedRowNum);
+      }
 
       parsedRowNum++;
       return columns;

--- a/Model/src/main/java/org/gusdb/wdk/model/dataset/ListDatasetParser.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/dataset/ListDatasetParser.java
@@ -6,7 +6,9 @@ import java.util.Arrays;
 import java.util.regex.Pattern;
 
 /**
- * Parser expecting a list of identifiers. The parser was originally intended to support multiple 
+ * Parser expecting a list of identifiers. The parser was originally intended to support multiple columns, but in its
+ * current state it regards \s, "," and ";" as row separators which functionally ensures that each row will have a
+ * single column. The exception to this would be if a colDivider distinct from these characters is provided.
  */
 public class ListDatasetParser extends AbstractDatasetParser {
   private static Pattern VALID_ID_PATTERN = Pattern.compile("[a-zA-Z0-9\\(\\)\\.\\:_-]+");


### PR DESCRIPTION
Resolves #47 

Added validation to ListDatasetParser to avoid attempting to search for invalid IDs from junky text files. The regex we came to in the PR is based off discussions with outreach and analysis of existing IDs in the system.

Tested on https://dgaldi.plasmodb.org/plasmo.dgaldi/app/search/transcript/GeneByLocusTag

![Screen Shot 2022-09-02 at 9 56 07 AM](https://user-images.githubusercontent.com/3497580/188165324-33d01776-d0e6-4304-8468-e82d22f92739.png)
