### PR TITLE
Updating UD installer to persist project information in core tables

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/UserDatasetEventSyncHandler.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/UserDatasetEventSyncHandler.java
@@ -217,7 +217,7 @@ public class UserDatasetEventSyncHandler extends UserDatasetEventHandler
     files = copyToLocalTimeout(dsSession, userDataset, typeHandler, cwd);
 
     // insert into the installedTable
-    getInstallRepo().insertUserDataset(datasetId, userDataset.getMeta().getName());
+    getInstallRepo().insertUserDataset(datasetId, userDataset.getMeta().getName(), getProjectId());
 
     // insert into the type-specific tables
     typeHandler.installInAppDb(userDataset, cwd, getProjectId(), files);

--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
@@ -39,7 +39,7 @@ import java.util.Set;
 public class InstalledUserDatasetDBActions
 {
   private static final String TABLE_INSTALLED_USER_DATASET = "installeduserdataset";
-  private static final String TABLE_INSTALLED_USER_DATASET_PROJ = "installeduserdatasetproject";
+  private static final String TABLE_INSTALLED_USER_DATASET_PROJ = "userdatasetproject";
 
   private final String     schema;
   private final DataSource ds;

--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
@@ -65,33 +65,20 @@ public class InstalledUserDatasetDBActions
     // Use a merge in case a dataset is installed by two separate project installers.
     // Only insert if not matched.
     var insertUserDatasetSql = "MERGE INTO " + schema + TABLE_INSTALLED_USER_DATASET + " datasets" +
-      " USING (SELECT ? user_dataset_id, ? name from dual) to_insert" +
+        " USING (SELECT ? user_dataset_id, ? name FROM dual) to_insert" +
         " ON (datasets.user_dataset_id = to_insert.user_dataset_id)" +
-        " WHEN NOT MATCHED THEN INSERT(user_dataset_id, name) VALUES (?, ?)";
+        " WHEN NOT MATCHED THEN INSERT(user_dataset_id, name) VALUES (to_insert.user_dataset_id, to_insert.name);" +
+        " INSERT INTO " + schema + TABLE_INSTALLED_USER_DATASET_PROJ +
+        " (user_dataset_id, project) VALUES (?, ?);";
 
-    new SQLRunner(ds, insertUserDatasetSql, "insert-user-dataset-row")
-      .executeUpdate(new Object[]{userDatasetID, name, userDatasetID, name});
-
-    // No need to merge here since row is specific to the installer being run.
-    var insertUserDatasetProjectSql = "INSERT INTO " + schema + TABLE_INSTALLED_USER_DATASET_PROJ +
-        " (user_dataset_id, project) VALUES (?, ?)";
-
-    new SQLRunner(ds, insertUserDatasetProjectSql, "insert-user-dataset-project-row")
-        .executeUpdate(new Object[]{userDatasetID, projectId});
+    new SQLRunner(ds, insertUserDatasetSql, "insert-user-dataset")
+        .executeUpdate(new Object[]{userDatasetID, name, userDatasetID, projectId});
   }
 
   public void deleteUserDataset(long userDatasetID) {
-    // Use a merge in case a dataset is installed by two separate project installers.
-    // Only insert if not matched.
-    var deleteUserDatasetSql = "MERGE INTO " + schema + TABLE_INSTALLED_USER_DATASET + " datasets" +
-        " USING (SELECT ? user_dataset_id, dummy name from dual) to_delete" +
-        " ON (datasets.user_dataset_id = to_delete.user_dataset_id)" +
-        " WHEN MATCHED THEN DELETE WHERE datasets.user_dataset_id = to_delete.user_dataset_id";
+    var deleteUserDatasetSql = "DELETE FROM " + schema + TABLE_INSTALLED_USER_DATASET + " WHERE user_dataset_id = ?;" +
+        " DELETE FROM " + schema + TABLE_INSTALLED_USER_DATASET_PROJ + " WHERE user_dataset_id = ?;";
 
-    new SQLRunner(ds, deleteUserDatasetSql, "delete-user-dataset-row").executeUpdate(new Object[]{userDatasetID});
-
-    var deleteUserDatasetProjectSql = "DELETE FROM " + schema + TABLE_INSTALLED_USER_DATASET_PROJ + " WHERE user_dataset_id = ?";
-
-    new SQLRunner(ds, deleteUserDatasetProjectSql, "delete-user-dataset-project-row").executeUpdate(new Object[]{userDatasetID});
+    new SQLRunner(ds, deleteUserDatasetSql, "delete-user-dataset").executeUpdate(new Object[]{userDatasetID, userDatasetID});
   }
 }

--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
@@ -68,7 +68,7 @@ public class InstalledUserDatasetDBActions
       " WHEN NOT MATCHED THEN INSERT(user_dataset_id, name) VALUES (?, ?)";
 
     new SQLRunner(ds, insertUserDatasetSql, "insert-user-dataset-row")
-      .executeUpdate(new Object[]{userDatasetID, name, userDatasetID});
+      .executeUpdate(new Object[]{userDatasetID, name});
 
     // No need to merge here since row is specific to the installer being run.
     var insertUserDatasetProjectSql = "INSERT INTO " + schema + TABLE_INSTALLED_USER_DATASET_PROJ +

--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
@@ -87,7 +87,7 @@ public class InstalledUserDatasetDBActions
 
     FunctionalInterfaces.ConsumerWithException<Connection> insertUserDatasetProjectFunction = conn -> {
       LOG.info("Executing update to UD with ID " + userDatasetID + " with name " + projectId);
-      new SQLRunner(ds, insertUserDatasetProjectSql, "insert-user-dataset-project-row")
+      new SQLRunner(conn, insertUserDatasetProjectSql, "insert-user-dataset-project-row")
           .executeUpdate(new Object[]{userDatasetID, projectId});
     };
 

--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
@@ -64,11 +64,13 @@ public class InstalledUserDatasetDBActions
   public void insertUserDataset(long userDatasetID, String name, String projectId) {
     // Use a merge in case a dataset is installed by two separate project installers.
     // Only insert if not matched.
-    var insertUserDatasetSql = "MERGE INTO " + schema + TABLE_INSTALLED_USER_DATASET +
-      " WHEN NOT MATCHED THEN INSERT(user_dataset_id, name) VALUES (?, ?)";
+    var insertUserDatasetSql = "MERGE INTO " + schema + TABLE_INSTALLED_USER_DATASET + " datasets" +
+      " USING (SELECT ? user_dataset_id, ? name from dual) to_insert" +
+        " ON (datasets.user_dataset_id = to_insert.user_dataset_id)" +
+        " WHEN NOT MATCHED THEN INSERT(user_dataset_id, name) VALUES (?, ?)";
 
     new SQLRunner(ds, insertUserDatasetSql, "insert-user-dataset-row")
-      .executeUpdate(new Object[]{userDatasetID, name});
+      .executeUpdate(new Object[]{userDatasetID, name, userDatasetID, name});
 
     // No need to merge here since row is specific to the installer being run.
     var insertUserDatasetProjectSql = "INSERT INTO " + schema + TABLE_INSTALLED_USER_DATASET_PROJ +

--- a/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/user/dataset/event/datastore/InstalledUserDatasetDBActions.java
@@ -74,7 +74,7 @@ public class InstalledUserDatasetDBActions
 
     // No need to merge here since row is specific to the installer being run.
     var insertUserDatasetProjectSql = "INSERT INTO " + schema + TABLE_INSTALLED_USER_DATASET_PROJ +
-        " (user_dataset_id, project_id) VALUES (?, ?)";
+        " (user_dataset_id, project) VALUES (?, ?)";
 
     new SQLRunner(ds, insertUserDatasetProjectSql, "insert-user-dataset-project-row")
         .executeUpdate(new Object[]{userDatasetID, projectId});


### PR DESCRIPTION
## Overview
* Updating UD installer to persist project information to database to unblock ClinEpiDB and MicroBiomeDB user datasets to co-exist in the EDA database
* Note that a change to [createUserDatasetCoreTables](https://github.com/VEuPathDB/ApiCommonData/blob/392981b6591750eb8c0224b149ff31229416c741/Load/lib/sql/apidbschema/createUserDatasetCoreTables.sql) will need to coincide with this change

## Testing
Ran the installer on palm against plasmoinc and dev irods testing both delete and install events