### PR TITLE
Query metrics

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/query/ProcessQueryInstance.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/ProcessQueryInstance.java
@@ -79,8 +79,7 @@ public class ProcessQueryInstance extends QueryInstance<ProcessQuery> {
   @Override
   public Optional<String> createCacheTableAndInsertResult(DatabaseInstance appDb, String tableName, long instanceId)
       throws WdkModelException {
-    return new QueryMetric(_wdkModel.getProjectId(), _query.getFullName())
-        .observeCacheInsertion(appDb, tableName, () -> {
+    return QueryMetrics.observeCacheInsertion(_query, tableName, () -> {
       createCacheTable(appDb, tableName, _query);
       return insertResults(appDb, tableName, instanceId);
     });

--- a/Model/src/main/java/org/gusdb/wdk/model/query/ProcessQueryInstance.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/ProcessQueryInstance.java
@@ -79,8 +79,11 @@ public class ProcessQueryInstance extends QueryInstance<ProcessQuery> {
   @Override
   public Optional<String> createCacheTableAndInsertResult(DatabaseInstance appDb, String tableName, long instanceId)
       throws WdkModelException {
-    createCacheTable(appDb, tableName, _query);
-    return insertResults(appDb, tableName, instanceId);
+    return new QueryMetric(_wdkModel.getProjectId(), _query.getFullName())
+        .observeCacheInsertion(appDb, tableName, () -> {
+      createCacheTable(appDb, tableName, _query);
+      return insertResults(appDb, tableName, instanceId);
+    });
   }
 
   private static void createCacheTable(DatabaseInstance appDb, String tableName, ProcessQuery query) throws WdkModelException {

--- a/Model/src/main/java/org/gusdb/wdk/model/query/QueryMetric.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/QueryMetric.java
@@ -1,0 +1,99 @@
+package org.gusdb.wdk.model.query;
+
+import java.util.Optional;
+
+import org.gusdb.fgputil.db.pool.DatabaseInstance;
+import org.gusdb.fgputil.db.runner.SQLRunner;
+import org.gusdb.fgputil.db.runner.SingleIntResultSetHandler;
+import org.gusdb.fgputil.functional.FunctionalInterfaces.SupplierWithException;
+import org.gusdb.wdk.model.WdkModelException;
+
+import io.prometheus.client.Histogram;
+
+/**
+ * Provides standard query metrics (reported via a prometheus metrics endpoint) for
+ * all queries run through the QueryInstance class.  These metrics include:
+ *
+ * - project ID
+ * - query full name
+ * - query duration (time to insert into WDK cache, binned)
+ * - query size (number of rows inserted to cache, binned)
+ *
+ */
+public class QueryMetric {
+
+  private static final double[] QUERY_TIME_MS_BINS = new double[] {
+      250, 1000, 3000, 10000, 25000, 60000, 120000, 300000, Double.POSITIVE_INFINITY
+  };
+
+  private static final Histogram QUERY_DURATION = Histogram.build()
+      .name("wdk_query_duration")
+      .help("WDK query duration in milliseconds")
+      .labelNames("project_id", "query_name", "result_size_magnatude")
+      .buckets(QUERY_TIME_MS_BINS)
+      .register();
+
+  private final String _projectId;
+  private final String _queryFullName;
+
+  public QueryMetric(String projectId, String queryFullName) {
+    _projectId = projectId;
+    _queryFullName = queryFullName;
+  }
+
+  public Optional<String> observeCacheInsertion(
+      DatabaseInstance appDb,
+      String cacheTableName,
+      SupplierWithException<Optional<String>> cacheCreator) throws WdkModelException {
+    try {
+
+      // time creation and population of the cache table
+      long timerStart = System.currentTimeMillis();
+      Optional<String> resultMessage = cacheCreator.get();
+      long duration = System.currentTimeMillis() - timerStart;
+
+      // get number of inserted rows
+      int resultSize = new SQLRunner(
+          appDb.getDataSource(), "select count(*) from " + cacheTableName,
+          "table_count_for_metrics"
+      ).executeQuery(new SingleIntResultSetHandler());
+
+      // register an observation in the histogram
+      QUERY_DURATION
+        .labels(
+          _projectId,
+          _queryFullName,
+          String.valueOf(orderOfMagnitude(resultSize)))
+        .observe(duration);
+
+      // return the message associated with this query execution
+      return resultMessage;
+    }
+    catch (WdkModelException | RuntimeException e) {
+      throw e;
+    }
+    catch (Exception e) {
+      // should not happen; this is an API problem
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Returns a logarithm-like value to show order of magnitude of a result size.  If size is
+   * zero, returns zero; else returns the floor(log10(resultSize)) + 1, yielding results like:
+   *
+   * f(0) = 0
+   * f(3) = 1
+   * f(12) = 2
+   * f(463) = 3
+   *
+   * This could also be done by converting the int to a String and returning length; but numeric is probably faster.
+   *
+   * @param resultSize
+   * @return
+   */
+  private static int orderOfMagnitude(int resultSize) {
+    return resultSize == 0 ? 0 :
+      Double.valueOf(Math.floor(Math.log10(Integer.valueOf(resultSize).doubleValue()))).intValue() + 1;
+  }
+}

--- a/Model/src/main/java/org/gusdb/wdk/model/query/QueryMetrics.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/QueryMetrics.java
@@ -21,15 +21,16 @@ import io.prometheus.client.Histogram;
  */
 public class QueryMetrics {
 
-  private static final double[] QUERY_TIME_MS_BINS = new double[] {
+  // represent the upper bound of duration bins in milliseconds
+  private static final double[] QUERY_DURATION_MS_BINS = new double[] {
       250, 1000, 3000, 10000, 25000, 60000, 120000, 300000, Double.POSITIVE_INFINITY
   };
 
   private static final Histogram QUERY_DURATION = Histogram.build()
       .name("wdk_query_duration")
       .help("WDK query duration in milliseconds")
-      .labelNames("project_id", "query_name", "result_size_magnatude")
-      .buckets(QUERY_TIME_MS_BINS)
+      .labelNames("project_id", "query_name", "result_size_magnitude")
+      .buckets(QUERY_DURATION_MS_BINS)
       .register();
 
   public static Optional<String> observeCacheInsertion(

--- a/Model/src/main/java/org/gusdb/wdk/model/query/SqlQueryInstance.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/SqlQueryInstance.java
@@ -78,8 +78,7 @@ public class SqlQueryInstance extends QueryInstance<SqlQuery> {
   @Override
   public Optional<String> createCacheTableAndInsertResult(DatabaseInstance appDb, String tableName, long instanceId)
       throws WdkModelException {
-    return new QueryMetric(_wdkModel.getProjectId(), _query.getFullName())
-        .observeCacheInsertion(appDb, tableName, () -> {
+    return QueryMetrics.observeCacheInsertion(_query, tableName, () -> {
       LOG.debug("Creating cache table for query " + _query.getFullName());
       // get the sql with param values applied.
       var sql = getUncachedSql();


### PR DESCRIPTION
Log query metrics whenever we run a WDK query to put records in the WDK cache.  If a query is not cacheable (setting in model XML) or is already cached, metrics are not collected.  Note turning off whitespace in the diff will show how little has changed in the ProcessQuery subclasses.