### PR TITLE
Enum fixes

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/query/param/AbstractEnumParam.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/param/AbstractEnumParam.java
@@ -213,7 +213,7 @@ public abstract class AbstractEnumParam extends AbstractDependentParam {
   }
 
   /**
-   * Returns the minimun number of selections allowed for this param; the value
+   * Returns the minimum number of selections allowed for this param; the value
    * in the model is intertwined with allowEmpty, which always takes precedence
    * in a conflict with this value.  Note that if this value is greater than
    * that returned by getMaxSelectedCount(), there may be an empty range of the
@@ -227,7 +227,7 @@ public abstract class AbstractEnumParam extends AbstractDependentParam {
    * @return The minimum number of allowed values for this param
    */
   public int getMinSelectedCount() {
-    return _minSelectedCount > 1 ? _minSelectedCount : _allowEmpty ? 0 : 1;
+    return _minSelectedCount > 0 ? _minSelectedCount : _allowEmpty ? 0 : 1;
   }
 
   /**
@@ -506,6 +506,11 @@ public abstract class AbstractEnumParam extends AbstractDependentParam {
   @Override
   protected boolean isEmptyValue(String value) {
     return super.isEmptyValue(value) || new JSONArray(value).length() == 0;
+  }
+
+  @Override
+  public boolean isAllowEmpty() {
+    return getMinSelectedCount() == 0;
   }
 
   /**

--- a/Model/src/main/java/org/gusdb/wdk/model/query/param/AbstractEnumParam.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/param/AbstractEnumParam.java
@@ -214,15 +214,15 @@ public abstract class AbstractEnumParam extends AbstractDependentParam {
 
   /**
    * Returns the minimum number of selections allowed for this param; the value
-   * in the model is intertwined with allowEmpty, which always takes precedence
-   * in a conflict with this value.  Note that if this value is greater than
+   * in the model is intertwined with allowEmpty, which can sometimes conflict
+   * with the model value.  Note that if this value is greater than
    * that returned by getMaxSelectedCount(), there may be an empty range of the
    * number of allowed values.
    *
-   * min-sel  -1  0  >0
+   * min-sel    -1  0  >0
    * --------------------
-   * allow 1   0  0  min
-   * empty 0   1  1  min
+   * allow| =1   0  0  min-sel
+   * empty| =0   1  1  min-sel
    *
    * @return The minimum number of allowed values for this param
    */

--- a/Model/src/main/java/org/gusdb/wdk/model/query/param/Param.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/param/Param.java
@@ -580,7 +580,7 @@ public abstract class Param extends WdkModelBase implements Cloneable, Comparabl
 
     // Determine if a default value must be generated
     boolean defaultValueRequired =
-        stableValues.get(getName()) == null &&
+        isEmptyValue(value) &&
         fillStrategy.shouldFillWhenMissing();
     validationLog(() -> "defaultValueRequired = " + defaultValueRequired + " because value = " +
         stableValues.get(getName()) + " and fillWhenMissing = " + fillStrategy.shouldFillWhenMissing());

--- a/Model/src/main/java/org/gusdb/wdk/model/query/param/Param.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/param/Param.java
@@ -83,7 +83,7 @@ public abstract class Param extends WdkModelBase implements Cloneable, Comparabl
 
   private static final Logger LOG = Logger.getLogger(Param.class);
 
-  public static final Level VALIDATION_LOG_PRIORITY = Level.INFO;
+  public static final Level VALIDATION_LOG_PRIORITY = Level.DEBUG;
 
   protected static final boolean EMPTY_DESPITE_ALLOWEMPTY_FALSE_IS_FATAL = false;
 

--- a/Model/src/main/java/org/gusdb/wdk/model/query/param/Param.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/param/Param.java
@@ -83,7 +83,7 @@ public abstract class Param extends WdkModelBase implements Cloneable, Comparabl
 
   private static final Logger LOG = Logger.getLogger(Param.class);
 
-  public static final Level VALIDATION_LOG_PRIORITY = Level.DEBUG;
+  public static final Level VALIDATION_LOG_PRIORITY = Level.INFO;
 
   protected static final boolean EMPTY_DESPITE_ALLOWEMPTY_FALSE_IS_FATAL = false;
 


### PR DESCRIPTION
This PR addresses two separate issues (combined only for testing convenience):

1. The issue at the bottom of https://redmine.apidb.org/issues/12938, namely for the `refreshed-dependent-params` endpoint to throw 422 instead of 500 in the following instance:
     a. Param A is a multi-pick enum param requiring >0 selected terms in a runnable context (but not displayable context)
     b. Param B is a filter param (enum would also have this problem) which depends on A and whose vocabulary queries cannot support an empty value (no selected terms) for Param A
     c. User clicks "Select None" in Param A, triggering a call to `refreshed-dependent-params` to get the new vocabulary and default value for Param B

2. The issue described in https://redmine.apidb.org/issues/51649, namely that membership filters in filter params cannot handle >1000 terms (SQL breaks Oracle's 1000 term limit in `in` clauses).