### PR TITLE
Reporter build tracking

### DIFF
--- a/Model/lib/rng/wdkModel.rng
+++ b/Model/lib/rng/wdkModel.rng
@@ -1383,6 +1383,7 @@
       <attribute name="displayName" />
       <attribute name="scopes" />
       <attribute name="implementation" />
+      <ref name="buildTracking" />
       <optional>
         <attribute name="inReportMaker">
           <data type="boolean" />
@@ -1398,6 +1399,15 @@
         <ref name="property" />
       </zeroOrMore>
     </element>
+  </define>
+
+  <define name="buildTracking">
+    <optional>
+      <choice>
+        <attribute name="newBuild" />
+        <attribute name="reviseBuild" />
+      </choice>
+    </optional>
   </define>
 
   <!-- Question -->
@@ -1430,12 +1440,7 @@
           <data type="boolean" />
         </attribute>
       </optional>
-      <optional>
-        <choice>
-          <attribute name="newBuild" />
-          <attribute name="reviseBuild" />
-        </choice>
-      </optional>
+      <ref name="buildTracking" />
 
       <zeroOrMore>
         <choice>

--- a/Model/src/main/java/org/gusdb/wdk/model/BuildTracking.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/BuildTracking.java
@@ -1,19 +1,15 @@
 package org.gusdb.wdk.model;
 
-import org.gusdb.wdk.model.RngAnnotations.RngOptional;
-
 public interface BuildTracking {
 
   WdkModel getWdkModel();
 
   String getNewBuild();
 
-  @RngOptional
   void setNewBuild(String newBuild);
 
   String getReviseBuild();
 
-  @RngOptional
   void setReviseBuild(String reviseBuild);
 
   /**

--- a/Model/src/main/java/org/gusdb/wdk/model/BuildTracking.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/BuildTracking.java
@@ -1,0 +1,38 @@
+package org.gusdb.wdk.model;
+
+public interface BuildTracking {
+
+  WdkModel getWdkModel();
+
+  String getNewBuild();
+
+  void setNewBuild(String newBuild);
+
+  String getReviseBuild();
+
+  void setReviseBuild(String reviseBuild);
+
+  /**
+   * @return if the object is newly introduced in the current build
+   */
+  default boolean isNew() {
+    return buildMatches(getNewBuild());
+  }
+
+  /**
+   * @return if the object is revised in the current build
+   */
+  default boolean isRevised() {
+    return buildMatches(getReviseBuild());
+  }
+
+  default boolean buildMatches(String trackedBuild) {
+    String currentBuild = getWdkModel().getBuildNumber();
+    if (currentBuild == null)
+      return false; // current release is not set
+    else
+      return currentBuild.equals(trackedBuild);
+    
+  }
+  
+}

--- a/Model/src/main/java/org/gusdb/wdk/model/BuildTracking.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/BuildTracking.java
@@ -1,15 +1,19 @@
 package org.gusdb.wdk.model;
 
+import org.gusdb.wdk.model.RngAnnotations.RngOptional;
+
 public interface BuildTracking {
 
   WdkModel getWdkModel();
 
   String getNewBuild();
 
+  @RngOptional
   void setNewBuild(String newBuild);
 
   String getReviseBuild();
 
+  @RngOptional
   void setReviseBuild(String reviseBuild);
 
   /**

--- a/Model/src/main/java/org/gusdb/wdk/model/question/Question.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/question/Question.java
@@ -20,6 +20,7 @@ import org.apache.log4j.Logger;
 import org.gusdb.fgputil.Named;
 import org.gusdb.fgputil.Named.NamedObject;
 import org.gusdb.fgputil.functional.Functions;
+import org.gusdb.wdk.model.BuildTracking;
 import org.gusdb.wdk.model.Utilities;
 import org.gusdb.wdk.model.WdkModel;
 import org.gusdb.wdk.model.WdkModelBase;
@@ -65,7 +66,7 @@ import org.gusdb.wdk.model.user.UserPreferences;
  * @version $Revision$ $Date: 2007-01-10 14:54:53 -0500 (Wed, 10 Jan
  *          2007) $ $Author$
  */
-public class Question extends WdkModelBase implements AttributeFieldContainer, StepAnalysisContainer, NamedObject {
+public class Question extends WdkModelBase implements AttributeFieldContainer, StepAnalysisContainer, NamedObject, BuildTracking {
 
   public static final String DYNAMIC_QUERY_SUFFIX = "_dynamic";
 
@@ -214,42 +215,24 @@ public class Question extends WdkModelBase implements AttributeFieldContainer, S
     return prefix + recordClass.getFullName().replace('.', '_');
   }
 
+  @Override
   public String getNewBuild() {
     return _newBuild;
   }
 
+  @Override
   public void setNewBuild(String newBuild) {
     _newBuild = newBuild;
   }
 
+  @Override
   public String getReviseBuild() {
     return _reviseBuild;
   }
 
+  @Override
   public void setReviseBuild(String reviseBuild) {
     _reviseBuild = reviseBuild;
-  }
-
-  /**
-   * @return if the question a newly introduced in the current build.
-   */
-  public boolean isNew() {
-    String currentBuild = _wdkModel.getBuildNumber();
-    if (currentBuild == null)
-      return false; // current release is not set
-    else
-      return (currentBuild.equals(_newBuild));
-  }
-
-  /**
-   * @return if the question is revised in the current build.
-   */
-  public boolean isRevised() {
-    String currentBuild = _wdkModel.getBuildNumber();
-    if (currentBuild == null)
-      return false; // current release is not set
-    else
-      return (currentBuild.equals(_reviseBuild));
   }
 
   public void addSuggestion(QuestionSuggestion suggestion) {

--- a/Model/src/main/java/org/gusdb/wdk/model/report/DynamicAttributeReporterReference.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/report/DynamicAttributeReporterReference.java
@@ -98,9 +98,9 @@ public class DynamicAttributeReporterReference extends AttributeReporterRef {
   public boolean hasAllDynamicFields() {
     return (
         getName() != null &&
-            getDisplayName() != null &&
-            getDescription() != null &&
-            getImplementation() != null
+        getDisplayName() != null &&
+        //getDescription() != null && // description is allowed to be null
+        getImplementation() != null
     );
   }
 
@@ -109,7 +109,7 @@ public class DynamicAttributeReporterReference extends AttributeReporterRef {
     String propsPrint = properties == null ? null : prettyPrint(properties, FormatUtil.Style.MULTI_LINE);
     return new StringBuilder("{").append(NL)
         .append("name:           ").append(getName()).append(NL)
-        .append("displayName:        ").append(getDisplayName()).append(NL)
+        .append("displayName:    ").append(getDisplayName()).append(NL)
         .append("description:    ").append(getDescription()).append(NL)
         .append("implementation: ").append(getImplementation()).append(NL)
         .append("properties:     ").append(propsPrint).append(NL)

--- a/Model/src/main/java/org/gusdb/wdk/model/report/ReporterRef.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/report/ReporterRef.java
@@ -167,6 +167,7 @@ public class ReporterRef extends WdkModelBase implements ScopedField, Properties
   }
 
   @Override
+  @RngOptional
   public void setNewBuild(String newBuild) {
     _newBuild = newBuild;
   }
@@ -177,6 +178,7 @@ public class ReporterRef extends WdkModelBase implements ScopedField, Properties
   }
 
   @Override
+  @RngOptional
   public void setReviseBuild(String reviseBuild) {
     _reviseBuild = reviseBuild;
   }

--- a/Model/src/main/java/org/gusdb/wdk/model/report/ReporterRef.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/report/ReporterRef.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
+import org.gusdb.wdk.model.BuildTracking;
 import org.gusdb.wdk.model.RngAnnotations.RngOptional;
 import org.gusdb.wdk.model.RngAnnotations.RngUndefined;
 import org.gusdb.wdk.model.WdkModel;
@@ -24,7 +25,7 @@ import org.gusdb.wdk.model.record.ScopedField;
  * @author xingao
  *
  */
-public class ReporterRef extends WdkModelBase implements ScopedField, PropertiesProvider {
+public class ReporterRef extends WdkModelBase implements ScopedField, PropertiesProvider, BuildTracking {
 
   private static final Logger LOG = Logger.getLogger(ReporterRef.class);
 
@@ -36,6 +37,16 @@ public class ReporterRef extends WdkModelBase implements ScopedField, Properties
   private boolean _inReportMaker = true;
   private List<WdkModelText> _propertyList = new ArrayList<>();
   private Map<String, String> _properties = new LinkedHashMap<>();
+
+  /**
+   * new build flag on what build this question is introduced.
+   */
+  private String _newBuild;
+
+  /**
+   * revise build flag on what build this question is revised.
+   */
+  private String _reviseBuild;
 
   @Override
   public WdkModel getWdkModel() {
@@ -148,6 +159,26 @@ public class ReporterRef extends WdkModelBase implements ScopedField, Properties
 
   public String getDescription() {
     return (_description == null ? _displayName : _description);
+  }
+
+  @Override
+  public String getNewBuild() {
+    return _newBuild;
+  }
+
+  @Override
+  public void setNewBuild(String newBuild) {
+    _newBuild = newBuild;
+  }
+
+  @Override
+  public String getReviseBuild() {
+    return _reviseBuild;
+  }
+
+  @Override
+  public void setReviseBuild(String reviseBuild) {
+    _reviseBuild = reviseBuild;
   }
 
   public void addProperty(WdkModelText property) {

--- a/Model/src/main/java/org/gusdb/wdk/model/report/ReporterRef.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/report/ReporterRef.java
@@ -158,7 +158,7 @@ public class ReporterRef extends WdkModelBase implements ScopedField, Properties
   }
 
   public String getDescription() {
-    return (_description == null ? _displayName : _description);
+    return _description;
   }
 
   @Override

--- a/Service/doc/schema/wdk/includes/record-reporter.json
+++ b/Service/doc/schema/wdk/includes/record-reporter.json
@@ -26,6 +26,12 @@
     },
     "type": {
       "type": "string"
+    },
+    "newBuild": {
+      "type": "string"
+    },
+    "reviseBuild": {
+      "type": "string"
     }
   },
   "required": [

--- a/Service/src/main/java/org/gusdb/wdk/service/formatter/RecordClassFormatter.java
+++ b/Service/src/main/java/org/gusdb/wdk/service/formatter/RecordClassFormatter.java
@@ -96,7 +96,9 @@ public class RecordClassFormatter {
           .put(JsonKeys.DISPLAY_NAME, reporter.getDisplayName())
           .put(JsonKeys.DESCRIPTION, reporter.getDescription())
           .put(JsonKeys.IS_IN_REPORT, FieldScope.REPORT_MAKER.isFieldInScope(reporter))
-          .put(JsonKeys.SCOPES, reporter.getScopesList());
+          .put(JsonKeys.SCOPES, reporter.getScopesList())
+          .put(JsonKeys.NEW_BUILD, reporter.getNewBuild())
+          .put(JsonKeys.REVISE_BUILD, reporter.getReviseBuild());
         array.put(obj);
       }
     }


### PR DESCRIPTION
Enables "standardized" build tracking on reporters.  Thus you can now have model XML like:
```
          <reporter name="bed" displayName="(SRT-NEW!) BED - coordinates of sequences, configurable" scopes="results" newBuild="66"
                    implementation="org.apidb.apicommon.model.report.bed.BedGeneReporter" />

          <reporter name="sequence" displayName="(SRT-NEW!) FASTA - sequence retrieval, configurable" scopes="results" newBuild="66"
                    implementation="org.apidb.apicommon.model.report.sequence.SequenceReporter" />
```
which produces reporter JSON (e.g. at https://rdoherty.plasmodb.org/plasmo.rdoherty/service/record-types/transcript) like:
```
    {
      "isInReport":true,
      "displayName":"(SRT-NEW!) BED - coordinates of sequences, configurable",
      "name":"bed",
      "description":"(SRT-NEW!) BED - coordinates of sequences, configurable",
      "scopes":[
        "results"
      ],
      "type":"bed",
      "newBuild":"66"
    },
    {
      "isInReport":true,
      "displayName":"(SRT-NEW!) FASTA - sequence retrieval, configurable",
      "name":"sequence",
      "description":"(SRT-NEW!) FASTA - sequence retrieval, configurable",
      "scopes":[
        "results"
      ],
      "type":"sequence",
      "newBuild":"66"
    },
```