### PR TITLE
Add searchVisibleHelp attribute to questions and visibleHelpPosition to params

### DIFF
--- a/Model/lib/rng/wdkModel.rng
+++ b/Model/lib/rng/wdkModel.rng
@@ -1461,6 +1461,11 @@
             <text />
           </element>
 
+          <element name="searchVisibleHelp">
+            <ref name="IncludeExclude" />
+            <text />
+          </element>
+
           <ref name="attributesList" />
 
           <element name="dynamicAttributes">

--- a/Model/lib/rng/wdkModel.rng
+++ b/Model/lib/rng/wdkModel.rng
@@ -288,6 +288,9 @@
 
   <define name="ParamBaseTags">
     <choice>
+      <optional>
+        <attribute name="visibleHelpPosition" />
+      </optional>
       <element name="visibleHelp">
         <ref name="IncludeExclude" />
         <text />
@@ -985,6 +988,9 @@
         <attribute name="max">
           <data type="double" />
         </attribute>
+      </optional>
+      <optional>
+        <attribute name="visibleHelpPosition" />
       </optional>
       <zeroOrMore>
         <element name="help">

--- a/Model/src/main/java/org/gusdb/wdk/core/api/JsonKeys.java
+++ b/Model/src/main/java/org/gusdb/wdk/core/api/JsonKeys.java
@@ -164,6 +164,7 @@ public class JsonKeys {
   public static final String PARSER = "parser";
   public static final String ALLOW_EMPTY_VALUE = "allowEmptyValue";
   public static final String VISIBLE_HELP = "visibleHelp";
+  public static final String VISIBLE_HELP_POSITION = "visibleHelpPosition";
 
   // dataset-related keys
   public static final String DEFAULT_ID_LIST = "defaultIdList";

--- a/Model/src/main/java/org/gusdb/wdk/core/api/JsonKeys.java
+++ b/Model/src/main/java/org/gusdb/wdk/core/api/JsonKeys.java
@@ -122,6 +122,7 @@ public class JsonKeys {
   public static final String PARAM_NAMES = "paramNames";
   public static final String QUERY_NAME = "queryName";
   public static final String IS_CACHEABLE = "isCacheable";
+  public static final String SEARCH_VISIBLE_HELP = "searchVisibleHelp";
 
   // record class specific keys
   public static final String HAS_ALL_RECORDS_QUERY = "hasAllRecordsQuery";

--- a/Model/src/main/java/org/gusdb/wdk/model/ModelXmlParser.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/ModelXmlParser.java
@@ -904,6 +904,9 @@ public class ModelXmlParser extends XmlParser {
     configureNode(digester, "wdkModel/questionSet/question/summary", WdkModelText.class, "addSummary");
     digester.addCallMethod("wdkModel/questionSet/question/summary", "setText", 0);
 
+    configureNode(digester, "wdkModel/questionSet/question/searchVisibleHelp", WdkModelText.class, "addSearchVisibleHelp");
+    digester.addCallMethod("wdkModel/questionSet/question/searchVisibleHelp", "setText", 0);
+
     // question's property list
     configureNode(digester, "wdkModel/questionSet/question/propertyList", PropertyList.class,
         "addPropertyList");

--- a/Model/src/main/java/org/gusdb/wdk/model/query/param/Param.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/param/Param.java
@@ -127,6 +127,7 @@ public abstract class Param extends WdkModelBase implements Cloneable, Comparabl
   // requested by PRISM, array will contain different values for different projects
   private List<WdkModelText> _visibleHelps;
   protected String _visibleHelp;
+  protected String _visibleHelpPosition;
 
   // both default value and empty values will be used to construct default raw value. these values themselves
   // are neither valid raw values nor stable values.  See FIXME below in getInternalValue()
@@ -191,6 +192,7 @@ public abstract class Param extends WdkModelBase implements Cloneable, Comparabl
     _prompt = param._prompt;
     _help = param._help;
     _visibleHelp = param._visibleHelp;
+    _visibleHelpPosition = param._visibleHelpPosition;
     _xmlDefaultValue = param._xmlDefaultValue;
     _sanityDefaultValue = param._sanityDefaultValue;
     _visible = param._visible;
@@ -290,6 +292,14 @@ public abstract class Param extends WdkModelBase implements Cloneable, Comparabl
 
   void setVisibleHelp(String visibleHelp) {
     _visibleHelp = visibleHelp;
+  }
+
+  public void setVisibleHelpPosition(String visibleHelpPosition) {
+    _visibleHelpPosition = visibleHelpPosition;
+  }
+
+  public String getVisibleHelpPosition() {
+    return _visibleHelpPosition;
   }
 
   /**
@@ -422,6 +432,7 @@ public abstract class Param extends WdkModelBase implements Cloneable, Comparabl
       .append("  prompt='").append(_prompt).append("'").append(NL)
       .append("  help='").append(_help).append("'").append(NL)
       .append("  visibleHelp='").append(_visibleHelp).append("'").append(NL)
+      .append("  visibleHelpPosition='").append(_visibleHelpPosition).append("'").append(NL)
       .append("  xmlDefault='").append(_xmlDefaultValue).append("'").append(NL)
       .append("  sanityDefault='").append(_sanityDefaultValue).append("'").append(NL)
       .append("  readonly=").append(_readonly).append(NL)

--- a/Model/src/main/java/org/gusdb/wdk/model/query/param/ParamReference.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/query/param/ParamReference.java
@@ -71,6 +71,10 @@ public class ParamReference extends Reference {
     if (visibleHelp != null)
       param.setVisibleHelp(visibleHelp);
 
+    String visibleHelpPosition = paramRef.getVisibleHelpPosition();
+    if (visibleHelpPosition != null)
+      param.setVisibleHelpPosition(visibleHelpPosition);
+
     // set prompt if any
     String prompt = paramRef.getPrompt();
     if (prompt != null)
@@ -276,6 +280,7 @@ public class ParamReference extends Reference {
 
   private List<WdkModelText> _visibleHelps = new ArrayList<WdkModelText>();
   private String _visibleHelp;
+  private String _visibleHelpPosition;
 
   // this property only applies to timestamp param.
   private Long _interval;
@@ -568,6 +573,14 @@ public class ParamReference extends Reference {
 
   public String getVisibleHelp() {
     return _visibleHelp;
+  }
+
+  public void setVisibleHelpPosition(String visibleHelpPosition) {
+    _visibleHelpPosition = visibleHelpPosition;
+  }
+
+  public String getVisibleHelpPosition() {
+    return _visibleHelpPosition;
   }
 
   public void setPrompt(String prompt) {

--- a/Model/src/main/java/org/gusdb/wdk/model/question/Question.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/question/Question.java
@@ -91,6 +91,9 @@ public class Question extends WdkModelBase implements AttributeFieldContainer, S
   private List<WdkModelText> _helps = new ArrayList<>();
   private String _help;
 
+  private List<WdkModelText> _searchVisibleHelps = new ArrayList<>();
+  private String _searchVisibleHelp;
+
   private QuestionSet _questionSet;
 
   private Query _query;
@@ -187,6 +190,7 @@ public class Question extends WdkModelBase implements AttributeFieldContainer, S
     _dynamicAttributeSet = question._dynamicAttributeSet;
 
     _help = question._help;
+    _searchVisibleHelp = question._searchVisibleHelp;
 
     // need to deep-copy query as well
     _query = question._query;
@@ -260,6 +264,10 @@ public class Question extends WdkModelBase implements AttributeFieldContainer, S
     _helps.add(help);
   }
 
+  public void addSearchVisibleHelp(WdkModelText searchVisibleHelp) {
+    _searchVisibleHelps.add(searchVisibleHelp);
+  }
+
   public void setRecordClassRef(String recordClassRef) {
     _recordClassRef = recordClassRef;
   }
@@ -328,6 +336,10 @@ public class Question extends WdkModelBase implements AttributeFieldContainer, S
 
   public String getHelp() {
     return _help;
+  }
+
+  public String getSearchVisibleHelp() {
+    return _searchVisibleHelp;
   }
 
   public String getDisplayName() {
@@ -718,6 +730,21 @@ public class Question extends WdkModelBase implements AttributeFieldContainer, S
       }
     }
     _helps = null;
+
+    // exclude searchVisibleHelps
+    boolean hasSearchVisibleHelp = false;
+    for (WdkModelText searchVisibleHelp : _searchVisibleHelps) {
+      if (searchVisibleHelp.include(projectId)) {
+        if (hasSearchVisibleHelp) {
+          throw new WdkModelException("The question " + getFullName()
+              + " has more than one searchVisibleHelp for project " + projectId);
+        } else {
+          _searchVisibleHelp = searchVisibleHelp.getText();
+          hasSearchVisibleHelp = true;
+        }
+      }
+    }
+    _searchVisibleHelps = null;
 
     // exclude summary and sorting attribute list
     boolean hasAttributeList = false;

--- a/Service/src/main/java/org/gusdb/wdk/service/formatter/QuestionFormatter.java
+++ b/Service/src/main/java/org/gusdb/wdk/service/formatter/QuestionFormatter.java
@@ -72,6 +72,7 @@ public class QuestionFormatter {
         .put(JsonKeys.ICON_NAME, q.getIconName())
         .put(JsonKeys.SUMMARY, q.getSummary())
         .put(JsonKeys.HELP, q.getHelp())
+        .put(JsonKeys.SEARCH_VISIBLE_HELP, q.getSearchVisibleHelp())
         .put(JsonKeys.NEW_BUILD, q.getNewBuild())
         .put(JsonKeys.REVISE_BUILD, q.getReviseBuild())
         .put(JsonKeys.IS_CACHEABLE, !q.getQuery().hasParamWithUncacheableQuery())

--- a/Service/src/main/java/org/gusdb/wdk/service/formatter/param/ParamFormatter.java
+++ b/Service/src/main/java/org/gusdb/wdk/service/formatter/param/ParamFormatter.java
@@ -50,6 +50,7 @@ public abstract class ParamFormatter<T extends Param> {
     pJson.put(JsonKeys.IS_READ_ONLY, _param.isReadonly());
     pJson.put(JsonKeys.ALLOW_EMPTY_VALUE, _param.isAllowEmpty());
     pJson.put(JsonKeys.VISIBLE_HELP, _param.getVisibleHelp());
+    pJson.put(JsonKeys.VISIBLE_HELP_POSITION, _param.getVisibleHelpPosition());
     pJson.put(JsonKeys.DEPENDENT_PARAMS, new JSONArray(
         mapToList(_param.getDependentParams(), NamedObject::getName)));
     pJson.put(JsonKeys.INITIAL_DISPLAY_VALUE,


### PR DESCRIPTION
Resolves https://redmine.apidb.org/issues/53977

Specifically, this request in the comments:
> at UX Apr 3 2024 it was suggested to have the help under the search title, not witin a parameter. This will help understanding the search better.

Depends on client changes from https://github.com/VEuPathDB/web-monorepo/pull/995 and model changes from https://github.com/VEuPathDB/ApiCommonModel/pull/42

**Note**: This also adds a `visibleHelpPosition` attribute to params, which is an older request.