### PR TITLE
Fix VDI entity ID retrieval

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/fix/table/edaanalysis/plugins/VDIEntityIdRetriever.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/fix/table/edaanalysis/plugins/VDIEntityIdRetriever.java
@@ -15,7 +15,7 @@ public class VDIEntityIdRetriever {
   }
 
   public Optional<String> queryEntityId(String vdiStableId) {
-    final String sql = String.format("SELECT internal_abbrev FROM %s.userstudydatasetid u" +
+    final String sql = String.format("SELECT stable_id FROM %s.userstudydatasetid u" +
         " JOIN %s.entitytypegraph etg" +
         " ON u.study_stable_id = etg.study_stable_id" +
         " WHERE dataset_stable_id = ?", schema, schema);
@@ -24,7 +24,7 @@ public class VDIEntityIdRetriever {
       if (!hasNext) {
         return Optional.empty();
       }
-      return Optional.ofNullable(rs.getString("internal_abbrev"));
+      return Optional.ofNullable(rs.getString("stable_id"));
     });
   }
 }


### PR DESCRIPTION
I mistakenly thought EDA dealt in `internal_abbrev`s instead of `stable_id`s.