### PR TITLE
Stream attribute reporter values to avoid OOM errors.

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/report/AbstractAttributeReporter.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/report/AbstractAttributeReporter.java
@@ -2,21 +2,21 @@ package org.gusdb.wdk.model.report;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 
-import javax.sql.DataSource;
-
+import org.gusdb.fgputil.Tuples;
 import org.gusdb.fgputil.db.SqlUtils;
+import org.gusdb.fgputil.db.stream.ResultSetIterator;
 import org.gusdb.wdk.model.WdkModel;
 import org.gusdb.wdk.model.WdkModelException;
+import org.gusdb.wdk.model.WdkRuntimeException;
 import org.gusdb.wdk.model.answer.AnswerValue;
 import org.gusdb.wdk.model.query.Column;
 import org.gusdb.wdk.model.query.SqlQuery;
-import org.gusdb.wdk.model.record.PrimaryKeyDefinition;
 import org.gusdb.wdk.model.record.PrimaryKeyValue;
 import org.gusdb.wdk.model.record.RecordClass;
 import org.gusdb.wdk.model.record.attribute.AttributeField;
@@ -26,6 +26,8 @@ import org.gusdb.wdk.model.record.attribute.PkColumnAttributeField;
 import org.gusdb.wdk.model.record.attribute.QueryColumnAttributeField;
 import org.gusdb.wdk.model.record.attribute.TextAttributeField;
 import org.json.JSONObject;
+
+import static org.gusdb.fgputil.functional.Functions.mapException;
 
 public abstract class AbstractAttributeReporter extends AbstractReporter {
 
@@ -158,37 +160,32 @@ public abstract class AbstractAttributeReporter extends AbstractReporter {
     return builder.append("'").toString();
   }
 
-  /**
-   * @return the values of the associated attribute. the key of the map is the
-   *         primary key of a record instance.
-   */
-  protected Map<PrimaryKeyValue, Object> getAttributeValues(AnswerValue answerValue)
-      throws WdkModelException, SQLException {
-    WdkModel wdkModel = answerValue.getWdkModel();
-    Map<PrimaryKeyValue, Object> values = new LinkedHashMap<>();
-    RecordClass recordClass = answerValue.getAnswerSpec().getQuestion().getRecordClass();
-    PrimaryKeyDefinition pkDef = recordClass.getPrimaryKeyDefinition();
-    String[] pkColumns = pkDef.getColumnRefs();
-    String sql = getAttributeSql(answerValue);
-    DataSource dataSource = wdkModel.getAppDb().getDataSource();
-    ResultSet resultSet = null;
-    try {
-      resultSet = SqlUtils.executeQuery(dataSource, sql,
-          answerValue.getAnswerSpec().getQuestion().getQuery().getFullName()
-              + "__attribute-plugin-combined", 5000);
-      while (resultSet.next()) {
-        Map<String, Object> pkValues = new LinkedHashMap<>();
-        for (String pkColumn : pkColumns) {
-          pkValues.put(pkColumn, resultSet.getObject(pkColumn));
-        }
-        PrimaryKeyValue pkValue = new PrimaryKeyValue(pkDef, pkValues);
-        Object value = resultSet.getObject(ATTRIBUTE_COLUMN);
-        values.put(pkValue, value);
-      }
-    } finally {
-      SqlUtils.closeResultSetAndStatement(resultSet, null);
-    }
-    return values;
-  }
+  protected ResultSetIterator<Tuples.TwoTuple<PrimaryKeyValue, Object>> getAttributeValueStream(AnswerValue answerValue)
+  throws WdkModelException, SQLException {
+    var pkDef = answerValue.getAnswerSpec()
+      .getQuestion()
+      .getRecordClass()
+      .getPrimaryKeyDefinition();
 
+    var pkColumns = pkDef.getColumnRefs();
+
+    var resultSet = SqlUtils.executeQuery(
+      answerValue.getWdkModel().getAppDb().getDataSource(),
+      getAttributeSql(answerValue),
+      answerValue.getAnswerSpec().getQuestion().getQuery().getFullName() + "__attribute-plugin-combined",
+      5000
+    );
+
+    return new ResultSetIterator<>(resultSet, row -> {
+      var pkValues = new LinkedHashMap<String, Object>(pkColumns.length);
+
+      for (var pkColumn : pkColumns)
+        pkValues.put(pkColumn, resultSet.getObject(pkColumn));
+
+      return Optional.of(new Tuples.TwoTuple<>(
+        mapException(() -> new PrimaryKeyValue(pkDef, pkValues), WdkRuntimeException::new),
+        resultSet.getObject(ATTRIBUTE_COLUMN)
+      ));
+    });
+  }
 }


### PR DESCRIPTION
### Problem

OOM errors for building giant maps of attribute values by primary key, in memory, where there is no current use case for lookups.

When the reproduceable OOM happens, the attribute value map is holding ~915M of memory across ~2.6 million k/v pairs.  The individual values in this case are comma separated lists of IDs.  

Example Value:
```
PF00630, PF18199, PF18198, PF17857, PF17852, PF13964, PF12781, PF12780, PF12777, PF12775, PF12774, PF08393, PF07646, PF03028, PF01833, PF01344
```


### Proposed Solution

Stream the attribute value query results instead of collecting them into an intermediary map.


### Additional Notes

Going by code searches performed by Steve, Dave, and I, it appears that the `AbstractAttributeReporter#getAttributeValue` method is only called by `WordCloudAttributeReporter`, and that reporter disregards the keys and simply iterates through the values.
