### PR TITLE
Cuts max runtime memory for Strings in table in half

### DIFF
--- a/Model/src/main/java/org/gusdb/wdk/model/report/reporter/FullRecordReporter.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/report/reporter/FullRecordReporter.java
@@ -5,15 +5,17 @@ import static org.gusdb.fgputil.FormatUtil.NL;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 import org.apache.log4j.Logger;
-import org.gusdb.fgputil.Tuples.TwoTuple;
+import org.gusdb.fgputil.Tuples.ThreeTuple;
+import org.gusdb.fgputil.functional.FunctionalInterfaces.FunctionWithException;
+import org.gusdb.fgputil.functional.FunctionalInterfaces.ProcedureWithException;
 import org.gusdb.wdk.model.WdkModelException;
 import org.gusdb.wdk.model.WdkRuntimeException;
 import org.gusdb.wdk.model.WdkUserException;
@@ -41,7 +43,7 @@ public class FullRecordReporter extends StandardReporter {
 
   private static Logger LOG = Logger.getLogger(FullRecordReporter.class);
 
-  private static final Function<TableValue, TwoTuple<Integer,String>> TABLE_FORMATTER = tableValue -> formatTable(tableValue);
+  private static final FunctionWithException<ThreeTuple<TableValue,Writer,Boolean>,Integer> TABLE_FORMATTER = inputs -> formatTable(inputs);
 
   private TableCache _tableCache = null;
 
@@ -156,35 +158,52 @@ public class FullRecordReporter extends StandardReporter {
   /**
    * Returns a tuple of table_size (# of rows) and formatted string
    * 
-   * @param tableValue table value for one row
+   * @param inputs table value for one row
    * @return table size and formatted table
    * @throws WdkRuntimException if unable to format table
    */
-  private static TwoTuple<Integer,String> formatTable(TableValue tableValue) {
+  private static int formatTable(ThreeTuple<TableValue, Writer, Boolean> inputs) {
     try {
+      TableValue tableValue = inputs.getFirst();
       TableField table = tableValue.getTableField();
       Collection<AttributeField> fields = table.getReporterAttributeFieldMap().values();
+      Writer out = inputs.getSecond();
+      boolean includeEmptyTables = inputs.getThird();
+
       // output table header
-      StringBuffer sb = new StringBuffer();
-      sb.append("Table: " + table.getDisplayName() + NL);
-      for (AttributeField attribute : fields) {
-        sb.append("[").append(attribute.getDisplayName()).append("]\t");
-      }
-      sb.append(NL);
-  
+      ProcedureWithException writeHeader = () -> {
+        out.write("Table: " + table.getDisplayName() + NL);
+        for (AttributeField attribute : fields) {
+          out.write("[");
+          out.write(attribute.getDisplayName());
+          out.write("]\t");
+        }
+        out.write(NL);
+      };
+
       int tableSize = 0;
       for (Map<String, AttributeValue> row : tableValue) {
+
+        // rows present; write header first time through the loop
+        if (tableSize == 0) writeHeader.perform();
         tableSize++;
         for (AttributeField field : fields) {
           AttributeValue value = row.get(field.getName());
-          sb.append(value.getValue()).append("\t");
+          out.write(value.getValue());
+          out.write("\t");
         }
-        sb.append(NL);
+        out.write(NL);
       }
+
+      // even if no rows, print header if includeEmptyTables is true
+      if (tableSize == 0 && includeEmptyTables) {
+        writeHeader.perform();
+      }
+
       //LOG.debug("FullRecordReporter: formatTable(): tableSize: " + tableSize);
-      return new TwoTuple<Integer, String>(tableSize, sb.toString());
+      return tableSize;
     }
-    catch (WdkModelException | WdkUserException e) {
+    catch (Exception e) {
       throw new WdkRuntimeException("Unable to format table value", e);
     }
   }

--- a/Model/src/main/java/org/gusdb/wdk/model/report/reporter/XMLReporter.java
+++ b/Model/src/main/java/org/gusdb/wdk/model/report/reporter/XMLReporter.java
@@ -5,15 +5,16 @@ import static org.gusdb.fgputil.FormatUtil.NL;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Function;
 
 import org.apache.log4j.Logger;
-import org.gusdb.fgputil.Tuples.TwoTuple;
+import org.gusdb.fgputil.Tuples.ThreeTuple;
+import org.gusdb.fgputil.functional.FunctionalInterfaces.FunctionWithException;
 import org.gusdb.wdk.model.WdkModelException;
 import org.gusdb.wdk.model.WdkRuntimeException;
 import org.gusdb.wdk.model.WdkUserException;
@@ -33,7 +34,7 @@ public class XMLReporter extends StandardReporter {
 
   private static Logger LOG = Logger.getLogger(XMLReporter.class);
 
-  private static final Function<TableValue, TwoTuple<Integer,String>> TABLE_XML_FORMATTER = tableValue -> formatTable(tableValue);
+  private static final FunctionWithException<ThreeTuple<TableValue,Writer,Boolean>,Integer> TABLE_XML_FORMATTER = inputs -> formatTable(inputs);
 
   private TableCache _tableCache;
 
@@ -128,27 +129,39 @@ public class XMLReporter extends StandardReporter {
     writer.flush();
   }
 
-  private static TwoTuple<Integer, String> formatTable(TableValue tableValue) {
+  private static int formatTable(ThreeTuple<TableValue, Writer, Boolean> inputs) {
     try {
+      TableValue tableValue = inputs.getFirst();
       TableField table = tableValue.getTableField();
-      StringBuilder sb = new StringBuilder();
-      sb.append("      <table name=\"" + table.getDisplayName() + "\">" + NL);
-      int tableSize = 0;
       Collection<AttributeField> reportTableFields = table.getReporterAttributeFieldMap().values();
+      Writer out = inputs.getSecond();
+      boolean includeEmptyTables = inputs.getThird();
+
+      String tableBegin = "      <table name=\"" + table.getDisplayName() + "\">" + NL;
+      String tableEnd   = "      </table>" + NL;
+
+      int tableSize = 0;
       for (Map<String, AttributeValue> row : tableValue) {
         tableSize++;
-        sb.append("        <row>" + NL);
+        if (tableSize == 1) out.write(tableBegin);
+        out.write("        <row>" + NL);
         for (AttributeField field : reportTableFields) {
           String fieldName = field.getName();
           AttributeValue value = row.get(fieldName);
-          sb.append("          <field name=\"" + fieldName + "\"><![CDATA[" + value.getValue() + "]]></field>" + NL);
+          out.write("          <field name=\"" + fieldName + "\"><![CDATA[" + value.getValue() + "]]></field>" + NL);
         }
-        sb.append("        </row>" + NL);
+        out.write("        </row>" + NL);
       }
-      sb.append("      </table>" + NL);
-      return new TwoTuple<Integer, String>(tableSize, sb.toString());
+
+      // if didn't already write tableBegin but writing empty table XML...
+      if (tableSize == 0 && includeEmptyTables) out.write(tableBegin);
+
+      // if wrote some rows or writing empty table XML...
+      if (tableSize > 0 || includeEmptyTables) out.write(tableEnd);
+
+      return tableSize;
     }
-    catch (WdkUserException | WdkModelException e) {
+    catch (Exception e) {
       throw new WdkRuntimeException("Unable to format table value into XML", e);
     }
   }


### PR DESCRIPTION
WDK table values can sometimes be very large.  Not loading all table rows into memory is a larger fix, but for now we can prevent them from _also_ being copied into a large concatenated string (along with extra formatting chars) before being written to the output stream.  Note this does not work for reporters using table cache but luckily the only reporter using that is gff.